### PR TITLE
Implemented requested changes for import_table

### DIFF
--- a/import_table.py
+++ b/import_table.py
@@ -67,7 +67,8 @@ with open(sys.argv[1], 'r', encoding='utf-8') as csv_file:
         assert sys.argv[1].lower().endswith('.csv')
         reader = csv.DictReader(csv_file, delimiter=',')
     except AssertionError:
-        raise BaseException('Not a CSV file. Check format and resubmit.')
+        print('ERROR: Not a CSV file. Check format and resubmit.')
+        sys.exit(2)
 
     # Verify that the file has all the attributes we need.
     try:
@@ -75,9 +76,11 @@ with open(sys.argv[1], 'r', encoding='utf-8') as csv_file:
         attributes.remove('Progress')
         attributes.remove('Email')
     except TypeError:
-        raise ValueError('CSV file not formatted correctly. Check file contents and resubmit.')
+        print('ERROR: CSV file not formatted correctly. Check file contents and resubmit.')
+        sys.exit(2)
     except KeyError:
-        raise ValueError('CSV file missing required attributes. Check file contents and resubmit.')
+        print('ERROR: CSV file missing required attributes. Check file contents and resubmit.')
+        sys.exit(2)
 
     # Check if we are importing the participant or volunteer form.
     is_participant = False

--- a/import_table.py
+++ b/import_table.py
@@ -56,16 +56,19 @@ start_time = time.time()
 with open(sys.argv[1], 'r', encoding="utf-8") as csv_file:
     # Try to open the provided file name.
     try:
+        assert sys.argv[1].lower().endswith('.csv')
         reader = csv.DictReader(csv_file, delimiter=',')
-    except:
-        raise BaseException('Cannot read/import CSV file. Check format and resubmit.')
+    except AssertionError:
+        raise BaseException('Not a CSV file. Check format and resubmit.')
 
     # Verify that the file has all the attributes we need.
-    attributes = set(reader.fieldnames)
     try:
+        attributes = set(reader.fieldnames)
         attributes.remove('Progress')
         attributes.remove('Email')
-    except:
+    except TypeError:
+        raise ValueError('CSV file not formatted correctly. Check file contents and resubmit.')
+    except KeyError:
         raise ValueError('CSV file missing required attributes. Check file contents and resubmit.')
 
     # Check if we are importing the participant or volunteer form.
@@ -73,7 +76,7 @@ with open(sys.argv[1], 'r', encoding="utf-8") as csv_file:
     data_attr = VOLUNTEER_DATA_ATTR
     try:
         attributes.remove('Roles')
-    except:
+    except KeyError:
         is_participant = True
         data_attr = PARTICIPANT_DATA_ATTR
 
@@ -112,7 +115,7 @@ with open(sys.argv[1], 'r', encoding="utf-8") as csv_file:
         for attribute in data_attr.keys():
             try:
                 data[data_attr[attribute]] = entry[attribute]
-            except:
+            except KeyError:
                 pass
 
         # Add this entry's data to the database if it is not a duplicate.
@@ -125,7 +128,7 @@ with open(sys.argv[1], 'r', encoding="utf-8") as csv_file:
             for attribute in data_attr.values():
                 try:
                     is_duplicate = is_duplicate and old_entry['data'][attribute] == data[attribute]
-                except:
+                except KeyError:
                     # If a key does not exist, then an attribute was added to data_attr.
                     is_duplicate = False
                     break
@@ -134,7 +137,7 @@ with open(sys.argv[1], 'r', encoding="utf-8") as csv_file:
             for attribute in old_entry['data'].keys():
                 try:
                     is_duplicate = is_duplicate and old_entry['data'][attribute] == data[attribute]
-                except:
+                except KeyError:
                     # If a key does not exist, then an attribute was removed from data_attr.
                     is_duplicate = False
                     break

--- a/import_table.py
+++ b/import_table.py
@@ -53,7 +53,15 @@ num_unfinished = 0
 num_entries = 0
 start_time = time.time()
 
-with open(sys.argv[1], 'r', encoding="utf-8") as csv_file:
+# Check that the correct number of command line arguments were given.
+try:
+    assert len(sys.argv) == 2
+except AssertionError:
+    print('USAGE: import_table.py [csv_filename]')
+    print('csv_filename: the name of the CSV file to import.')
+    sys.exit(2)
+
+with open(sys.argv[1], 'r', encoding='utf-8') as csv_file:
     # Try to open the provided file name.
     try:
         assert sys.argv[1].lower().endswith('.csv')

--- a/import_table.py
+++ b/import_table.py
@@ -53,7 +53,7 @@ num_unfinished = 0
 num_entries = 0
 start_time = time.time()
 
-with open(sys.argv[1], 'r') as csv_file:
+with open(sys.argv[1], 'r', encoding="utf-8") as csv_file:
     # Try to open the provided file name.
     try:
         reader = csv.DictReader(csv_file, delimiter=',')


### PR DESCRIPTION
I implemented the following changes as requested by @tonychen05 in #40:
- Specified a specific character encoding (UTF-8) when attempting to open the CSV file.
- Added a check for the correct number of command line arguments, and printed a help message if an incorrect number of arguments was provided.
- Specified the exceptions handled by various `except` clauses.
    - I also improved the error messages by printing an error message and calling `sys.exit(2)`, as opposed printing an error message while raising another exception.